### PR TITLE
Feat: 스터디룸 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/pomodoro/pomodoromate/PomodoroMateApplication.java
+++ b/src/main/java/com/pomodoro/pomodoromate/PomodoroMateApplication.java
@@ -2,20 +2,11 @@ package com.pomodoro.pomodoromate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 
 @SpringBootApplication
 public class PomodoroMateApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PomodoroMateApplication.class, args);
-	}
-
-	@Bean
-	public WebSecurityCustomizer ignoringCustomizer() {
-		return (web) -> web.ignoring()
-				.requestMatchers(PathRequest.toStaticResources().atCommonLocations());
 	}
 }

--- a/src/main/java/com/pomodoro/pomodoromate/common/models/BaseEntity.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/models/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.pomodoro.pomodoromate.common.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+    @Column(updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updateAt;
+
+    public LocalDateTime createAt() {
+        return createAt;
+    }
+
+    public LocalDateTime updateAt() {
+        return updateAt;
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/common/models/EntityId.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/models/EntityId.java
@@ -1,0 +1,48 @@
+package com.pomodoro.pomodoromate.common.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.MappedSuperclass;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@MappedSuperclass
+public abstract class EntityId implements Serializable {
+    @Column(name = "id")
+    private Long value;
+
+    public EntityId() {
+    }
+
+    public EntityId(Long value) {
+        this.value = value;
+    }
+
+    public Long getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "Id: " + value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EntityId other = (EntityId) o;
+        return Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/config/SecurityConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.pomodoro.pomodoromate.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+//        http.authorizeHttpRequests((requests) ->
+//                requests.anyRequest());
+        http.sessionManagement((session) ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer ignoringCustomizer() {
+        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/config/WebMvcConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/config/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package com.pomodoro.pomodoromate.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomService.java
@@ -1,0 +1,36 @@
+package com.pomodoro.pomodoromate.studyRoom.applications;
+
+import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
+import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CreateStudyRoomService {
+    private final StudyRoomRepository studyRoomRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public CreateStudyRoomService(StudyRoomRepository studyRoomRepository,
+                                  PasswordEncoder passwordEncoder) {
+        this.studyRoomRepository = studyRoomRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public Long create(CreateStudyRoomRequest request) {
+        StudyRoom studyRoom = new StudyRoom(
+                request.getInfo()
+//                request.getStatus()
+        );
+
+//        if (request.getStatus().equals(StudyRoomStatus.PASSWORD_PROTECTED)) {
+//            studyRoom.changePassword(request.getPassword(), passwordEncoder);
+//        }
+
+        StudyRoom saved = studyRoomRepository.save(studyRoom);
+
+        return saved.id();
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
@@ -1,0 +1,37 @@
+package com.pomodoro.pomodoromate.studyRoom.controllers;
+
+import com.pomodoro.pomodoromate.studyRoom.applications.CreateStudyRoomService;
+import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
+import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequestDto;
+import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomIntroLengthException;
+import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNameLengthException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("studyrooms")
+public class StudyRoomController {
+    private final CreateStudyRoomService createStudyRoomService;
+
+    public StudyRoomController(CreateStudyRoomService createStudyRoomService) {
+        this.createStudyRoomService = createStudyRoomService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> create(
+            @Validated @RequestBody CreateStudyRoomRequestDto requestDto
+    ) {
+        CreateStudyRoomRequest request = CreateStudyRoomRequest.of(requestDto);
+
+        Long studyRoomId = createStudyRoomService.create(request);
+
+        return ResponseEntity.created(URI.create("/studyrooms/" + studyRoomId)).build();
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomRequest.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomRequest.java
@@ -1,0 +1,39 @@
+package com.pomodoro.pomodoromate.studyRoom.dtos;
+
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomInfo;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomPassword;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomStatus;
+
+public class CreateStudyRoomRequest {
+    private StudyRoomInfo info;
+//    private StudyRoomPassword password;
+//    private StudyRoomStatus status;
+
+    public CreateStudyRoomRequest(StudyRoomInfo info) {
+        this.info = info;
+//        this.password = password;
+//        this.status = status;
+    }
+
+    public static CreateStudyRoomRequest of(CreateStudyRoomRequestDto requestDto) {
+        return new CreateStudyRoomRequest(
+                new StudyRoomInfo(requestDto.name(), requestDto.intro())
+//                new StudyRoomPassword(requestDto.password()),
+//                requestDto.isPrivate() ? StudyRoomStatus.PRIVATE :
+//                        requestDto.password().length() == 0 ? StudyRoomStatus.NORMAL :
+//                                StudyRoomStatus.PASSWORD_PROTECTED
+        );
+    }
+
+    public StudyRoomInfo getInfo() {
+        return info;
+    }
+
+//    public StudyRoomPassword getPassword() {
+//        return password;
+//    }
+//
+//    public StudyRoomStatus getStatus() {
+//        return status;
+//    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomRequestDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomRequestDto.java
@@ -1,0 +1,11 @@
+package com.pomodoro.pomodoromate.studyRoom.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateStudyRoomRequestDto(
+        @NotBlank String name,
+        String intro
+//        Boolean isPrivate,
+//        String password
+) {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/IncorrectStudyRoomPasswordException.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/IncorrectStudyRoomPasswordException.java
@@ -1,0 +1,7 @@
+package com.pomodoro.pomodoromate.studyRoom.exceptions;
+
+public class IncorrectStudyRoomPasswordException extends RuntimeException {
+    public IncorrectStudyRoomPasswordException() {
+        super("비밀번호가 틀렸습니다. 다시 시도해주세요.");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/InvalidStudyRoomPasswordException.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/InvalidStudyRoomPasswordException.java
@@ -1,0 +1,7 @@
+package com.pomodoro.pomodoromate.studyRoom.exceptions;
+
+public class InvalidStudyRoomPasswordException extends RuntimeException {
+    public InvalidStudyRoomPasswordException() {
+        super("비밀번호는 숫자 4자리 이상, 8자리 이하로 입력해주세요.");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/StudyRoomIntroLengthException.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/StudyRoomIntroLengthException.java
@@ -1,0 +1,7 @@
+package com.pomodoro.pomodoromate.studyRoom.exceptions;
+
+public class StudyRoomIntroLengthException extends RuntimeException {
+    public StudyRoomIntroLengthException(int maxIntroLength) {
+        super("스터디룸 소개 글은 최대 " + maxIntroLength + "자 이내로 입력해주세요.");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/StudyRoomNameLengthException.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/exceptions/StudyRoomNameLengthException.java
@@ -1,0 +1,8 @@
+package com.pomodoro.pomodoromate.studyRoom.exceptions;
+
+public class StudyRoomNameLengthException extends RuntimeException {
+    public StudyRoomNameLengthException(int minNameLength, int maxNameLength) {
+        super("스터디룸의 이름은 최소 " + minNameLength + "자, " +
+                "최대 " + maxNameLength + "자 이내로 입력해주세요.");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/Step.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/Step.java
@@ -1,0 +1,9 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+public enum Step {
+    PLANNING,
+    STUDYING,
+    RETROSPECT,
+    RESTING,
+    DONE
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoom.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoom.java
@@ -1,0 +1,96 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+import com.pomodoro.pomodoromate.common.models.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class StudyRoom extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated
+    private StudyRoomInfo info;
+
+//    @Enumerated
+//    @Column(name = "hostId")
+//    private UserId hostId;
+
+//    @Enumerated(EnumType.STRING)
+//    private StudyRoomStatus status;
+//
+//    @Enumerated
+//    private StudyRoomPassword password;
+
+    @Enumerated(EnumType.STRING)
+    private Step step;
+
+    public StudyRoom() {
+    }
+
+    public StudyRoom(Long id, StudyRoomInfo info) {
+        this.id = id;
+//        this.info = info;
+//        this.hostId = hostId;
+//        this.status = status;
+
+        this.step = Step.PLANNING;
+    }
+
+    public StudyRoom(StudyRoomInfo info) {
+        this.info = info;
+//        this.hostId = hostId;
+//        this.status = status;
+
+        this.step = Step.PLANNING;
+    }
+
+    public static StudyRoom fake(StudyRoomInfo info) {
+        return new StudyRoom(
+                1L,
+                info
+//                StudyRoomStatus.NORMAL
+        );
+    }
+
+//    public void changePassword(StudyRoomPassword password, PasswordEncoder passwordEncoder) {
+//        Pattern pattern = Pattern.compile(PASSWORD_PATTERN);
+//        Matcher matcher = pattern.matcher(password.getValue());
+//
+//        if (!matcher.find()) {
+//            throw new InvalidStudyRoomPasswordException();
+//        }
+//
+//        this.password = StudyRoomPassword.of(passwordEncoder.encode(password.getValue()));
+//    }
+//
+//    public void authenticate(StudyRoomPassword password, PasswordEncoder passwordEncoder) {
+//        if (!passwordEncoder.matches(password.getValue(), this.password.getValue())) {
+//            throw new IncorrectStudyRoomPasswordException();
+//        }
+//    }
+
+    public Long id() {
+        return id;
+    }
+
+    public StudyRoomInfo info() {
+        return info;
+    }
+
+//    public UserId hostId() {
+//        return hostId;
+//    }
+
+//    public StudyRoomPassword password() {
+//        return password;
+//    }
+
+    public Step step() {
+        return step;
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomId.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomId.java
@@ -1,0 +1,14 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+import com.pomodoro.pomodoromate.common.models.EntityId;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class StudyRoomId extends EntityId {
+    public StudyRoomId() {
+    }
+
+    public StudyRoomId(Long value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomInfo.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomInfo.java
@@ -1,0 +1,73 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomIntroLengthException;
+import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNameLengthException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+import static com.pomodoro.pomodoromate.studyRoom.policies.StudyRoomPolicy.MAX_INTRO_LENGTH;
+import static com.pomodoro.pomodoromate.studyRoom.policies.StudyRoomPolicy.MAX_NAME_LENGTH;
+import static com.pomodoro.pomodoromate.studyRoom.policies.StudyRoomPolicy.MIN_NAME_LENGTH;
+
+@Embeddable
+public class StudyRoomInfo {
+    @Column(name = "name", length = 30)
+    private String name;
+
+    @Column(name = "intro", length = 1000)
+    private String intro;
+
+    public StudyRoomInfo() {
+    }
+
+    public StudyRoomInfo(String name, String intro) {
+        validateName(name);
+        validateIntro(intro);
+
+        this.name = name;
+        this.intro = intro;
+    }
+
+    public void validateName(String name) {
+        if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
+            throw new StudyRoomNameLengthException(MIN_NAME_LENGTH, MAX_NAME_LENGTH);
+        }
+    }
+
+    public void validateIntro(String intro) {
+        if (intro.length() > MAX_INTRO_LENGTH) {
+            throw new StudyRoomIntroLengthException(MAX_INTRO_LENGTH);
+        }
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String intro() {
+        return intro;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        StudyRoomInfo other = (StudyRoomInfo) object;
+
+        return Objects.equals(name, other.name)
+                && Objects.equals(intro, other.intro);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, intro);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomPassword.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomPassword.java
@@ -1,0 +1,47 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+@Embeddable
+public class StudyRoomPassword {
+    @Column(name = "password")
+    private String value;
+
+    public StudyRoomPassword() {
+    }
+
+    public StudyRoomPassword(String value) {
+        this.value = value;
+    }
+
+    public static StudyRoomPassword of(String password) {
+        return new StudyRoomPassword(password);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        StudyRoomPassword otherPassword = (StudyRoomPassword) object;
+
+        return Objects.equals(value, otherPassword.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomStatus.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoomStatus.java
@@ -1,0 +1,7 @@
+package com.pomodoro.pomodoromate.studyRoom.models;
+
+public enum StudyRoomStatus {
+    NORMAL,
+    PASSWORD_PROTECTED,
+    PRIVATE
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/policies/StudyRoomPolicy.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/policies/StudyRoomPolicy.java
@@ -1,0 +1,10 @@
+package com.pomodoro.pomodoromate.studyRoom.policies;
+
+public class StudyRoomPolicy {
+    public static final int MIN_NAME_LENGTH = 2;
+    public static final int MAX_NAME_LENGTH = 30;
+
+    public static final int MAX_INTRO_LENGTH = 1000;
+
+    public static final String PASSWORD_PATTERN = "^[0-9]{4,8}$";
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepository.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepository.java
@@ -1,0 +1,10 @@
+package com.pomodoro.pomodoromate.studyRoom.repositories;
+
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRoomRepository extends JpaRepository<StudyRoom, StudyRoomId> {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/user/models/UserId.java
+++ b/src/main/java/com/pomodoro/pomodoromate/user/models/UserId.java
@@ -1,0 +1,12 @@
+package com.pomodoro.pomodoromate.user.models;
+
+import com.pomodoro.pomodoromate.common.models.EntityId;
+
+public class UserId extends EntityId {
+    public UserId() {
+    }
+
+    public UserId(Long value) {
+        super(value);
+    }
+}

--- a/src/test/java/com/pomodoro/pomodoromate/PomodoroMateApplicationTests.java
+++ b/src/test/java/com/pomodoro/pomodoromate/PomodoroMateApplicationTests.java
@@ -2,8 +2,10 @@ package com.pomodoro.pomodoromate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PomodoroMateApplicationTests {
 
 	@Test

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomServiceTest.java
@@ -1,0 +1,51 @@
+package com.pomodoro.pomodoromate.studyRoom.applications;
+
+import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomInfo;
+import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ActiveProfiles("test")
+class CreateStudyRoomServiceTest {
+    private StudyRoomRepository studyRoomRepository;
+    private PasswordEncoder passwordEncoder;
+    private CreateStudyRoomService createStudyRoomService;
+
+    @BeforeEach
+    void setUp() {
+        studyRoomRepository = mock(StudyRoomRepository.class);
+        passwordEncoder = mock(Argon2PasswordEncoder.class);
+        createStudyRoomService = new CreateStudyRoomService(
+                studyRoomRepository, passwordEncoder);
+    }
+
+    @Test
+    void create() {
+        StudyRoomInfo info = new StudyRoomInfo("스터디룸", "같이 공부해요");
+
+        CreateStudyRoomRequest request = new CreateStudyRoomRequest(
+                info
+//                new StudyRoomPassword(""),
+//                StudyRoomStatus.NORMAL
+        );
+
+        StudyRoom studyRoom = StudyRoom.fake(info);
+
+        given(studyRoomRepository.save(any()))
+                .willReturn(studyRoom);
+
+        Long savedId = createStudyRoomService.create(request);
+
+        assertThat(savedId).isNotNull();
+    }
+}

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
@@ -1,0 +1,42 @@
+package com.pomodoro.pomodoromate.studyRoom.controllers;
+
+import com.pomodoro.pomodoromate.config.SecurityConfig;
+import com.pomodoro.pomodoromate.studyRoom.applications.CreateStudyRoomService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StudyRoomController.class)
+@Import({SecurityConfig.class})
+class StudyRoomControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreateStudyRoomService createStudyRoomService;
+
+    @Test
+    void createStudyRoom() throws Exception {
+        given(createStudyRoomService.create(any()))
+                .willReturn(1L);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{" +
+                                "   \"name\": \"스터디\", " +
+                                "   \"intro\": \"공부할 사람 구해요\"" +
+//                                "   \"isPrivate\": \"false\", " +
+//                                "   \"password\": \"\"" +
+                                "}"))
+                .andExpect(status().isCreated());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 스터디룸을 생성하는 API 구현
- Spring Security : Web Ignore 설정

## 이슈
- 403 에러

    - 스프링 시큐리티에 기본적으로 csrf 필터가 적용되어 있어서 발생 → 해제
    - 세션을 사용하지 않고, 상태를 저장하지 않는 REST API 를 사용하기 때문에 CSRF가 필요하지 않음
- 테스트코드에 config 적용 안됨
    - Import() 를 이용하여 해결 → Import({SecurityConfig.class})
    - Spring에서는 테스트 환경과 실제 애플리케이션 환경의 설정이 다르게 적용됨 → 따라서 Import 를 이용하여 테스트 환경에도 SecurityConfig 를 적용해야 함