### PR TITLE
Fix: 스터디룸 조회 이슈 해결

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/StudyRoomSummaryDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/StudyRoomSummaryDto.java
@@ -2,10 +2,42 @@ package com.pomodoro.pomodoromate.studyRoom.dtos;
 
 import com.pomodoro.pomodoromate.studyRoom.models.Step;
 
-public record StudyRoomSummaryDto(
-        Long id, String name, String intro, String step, Integer participantCount
-) {
+public class StudyRoomSummaryDto {
+        private Long id;
+        private String name;
+        private String intro;
+        private String step;
+        private Long participantCount;
+
+    public StudyRoomSummaryDto(Long id, String name, String intro, Step step, Long participantCount) {
+        this.id = id;
+        this.name = name;
+        this.intro = intro;
+        this.step = step.toString();
+        this.participantCount = participantCount;
+    }
+
     public static StudyRoomSummaryDto fake(Long id, String name) {
-        return new StudyRoomSummaryDto(id, name, "설명", Step.PLANNING.toString(), 2);
+        return new StudyRoomSummaryDto(id, name, "설명", Step.PLANNING, 2L);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIntro() {
+        return intro;
+    }
+
+    public String getStep() {
+        return step;
+    }
+
+    public Long getParticipantCount() {
+        return participantCount;
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
@@ -38,6 +38,7 @@ public class StudyRoomRepositoryImpl implements StudyRoomRepositoryQueryDsl {
                         studyRoom.step,
                         getActiveParticipantCount(studyRoom)
                 ))
+                .from(studyRoom)
                 .where(studyRoom.step.ne(Step.COMPLETED))
                 .orderBy(studyRoom.createAt.desc())
                 .offset(pageable.getOffset())

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomsServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomsServiceTest.java
@@ -49,6 +49,6 @@ class GetStudyRoomsServiceTest {
         StudyRoomSummariesDto studyRoomSummariesDto = getStudyRoomsService.studyRooms(page, userId);
 
         assertThat(studyRoomSummariesDto.studyRooms()).hasSize(2);
-        assertThat(studyRoomSummariesDto.studyRooms().get(0).name()).isEqualTo("스터디방 1");
+        assertThat(studyRoomSummariesDto.studyRooms().get(0).getName()).isEqualTo("스터디방 1");
     }
 }


### PR DESCRIPTION
- 원인: dto의 Step은 String인데 queryDsl을 이용해 dto를 생성할 때, Step 객체를 넘겨주어 이슈 발생
- 해결: dto 생성자에서 Step을 String으로 변환해주도록 변경