### PR TITLE
Chore: 백엔드 API URL 변경

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/auth/controllers/AuthController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/auth/controllers/AuthController.java
@@ -20,10 +20,12 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "인증 API")
 @RestController
+@RequestMapping("api")
 public class AuthController {
     private final GuestLoginService guestLoginService;
     private final IssueTokenService issueTokenService;

--- a/src/main/java/com/pomodoro/pomodoromate/config/SecurityConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/config/SecurityConfig.java
@@ -43,9 +43,9 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer ignoringCustomizer() {
         return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/auth/**"))
-                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/token"))
-                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/logout"))
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/auth/**"))
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.POST, "/api/token"))
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.DELETE, "/api/logout"))
                 .requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**"));
     }
 

--- a/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
@@ -12,11 +12,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 
 @RestController
+@RequestMapping("api")
 public class ParticipantController {
     private final ParticipateService participateService;
     private final LeaveStudyService leaveStudyService;

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
@@ -31,7 +31,7 @@ import java.net.URI;
 
 @Tag(name = "스터디룸 API")
 @RestController
-@RequestMapping("studyrooms")
+@RequestMapping("api/studyrooms")
 public class StudyRoomController {
     private final CreateStudyRoomService createStudyRoomService;
     private final GetStudyRoomsService getStudyRoomsService;

--- a/src/test/java/com/pomodoro/pomodoromate/auth/controllers/AuthControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/auth/controllers/AuthControllerTest.java
@@ -40,7 +40,7 @@ class AuthControllerTest {
         given(guestLoginService.login(any()))
                 .willReturn(TokenDto.fake());
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/auth/guest")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/guest")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"nickname\": \"닉네임_닉네임\"" +
@@ -53,7 +53,7 @@ class AuthControllerTest {
 
     @Test
     void guestLoginWithInvalidNickname() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/auth/guest")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/guest")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"nickname\": \"!!!\"" +
@@ -63,7 +63,7 @@ class AuthControllerTest {
 
     @Test
     void guestLoginWithInvalidNameUnder3() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/auth/guest")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/guest")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"nickname\": \"닉\"" +
@@ -73,7 +73,7 @@ class AuthControllerTest {
 
     @Test
     void guestLoginWithInvalidNameOver16() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/auth/guest")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/guest")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"nickname\": \"" + "닉".repeat(17) +"\"" +
@@ -89,7 +89,7 @@ class AuthControllerTest {
         given(issueTokenService.reissue(token))
                 .willReturn(TokenDto.fake());
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/token")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/token")
                         .cookie(cookie))
                 .andExpect(status().isCreated())
                 .andExpect(content().string(

--- a/src/test/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantControllerTest.java
@@ -47,7 +47,7 @@ class ParticipantControllerTest {
         given(participateService.participate(userId, StudyRoomId.of(studyRoomId)))
                 .willReturn(1L);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms/" + studyRoomId + "/participants")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/studyrooms/" + studyRoomId + "/participants")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isCreated());
     }
@@ -60,7 +60,7 @@ class ParticipantControllerTest {
         Long studyRoomId = 1L;
         Long participantId = 1L;
 
-        mockMvc.perform(MockMvcRequestBuilders.delete("/studyrooms/" + studyRoomId +
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/studyrooms/" + studyRoomId +
                                 "/participants/" + participantId)
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
@@ -60,7 +60,7 @@ class StudyRoomControllerTest {
         given(createStudyRoomService.create(any(), any()))
                 .willReturn(1L);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/studyrooms")
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
@@ -74,7 +74,7 @@ class StudyRoomControllerTest {
 
     @Test
     void createStudyRoomWithBlankName() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/studyrooms")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"name\": \"\", " +
@@ -87,7 +87,7 @@ class StudyRoomControllerTest {
 
     @Test
     void createStudyRoomWithInvalidNameUnder2() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/studyrooms")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"name\": \"스\", " +
@@ -100,7 +100,7 @@ class StudyRoomControllerTest {
 
     @Test
     void createStudyRoomWithInvalidNameOver30() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/studyrooms")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/studyrooms")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
                                 "   \"name\": \"" + "스".repeat(31) + "\", " +
@@ -128,7 +128,7 @@ class StudyRoomControllerTest {
         given(getStudyRoomsService.studyRooms(1, userId))
                 .willReturn(studyRoomSummariesDto);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/studyrooms")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/studyrooms")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(
@@ -149,7 +149,7 @@ class StudyRoomControllerTest {
         given(getStudyRoomService.studyRoom(studyRoomId, userId))
                 .willReturn(studyRoomDetailDto);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/studyrooms/" + studyRoomId)
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/studyrooms/" + studyRoomId)
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(
@@ -165,7 +165,7 @@ class StudyRoomControllerTest {
 
         Long studyRoomId = 1L;
 
-        mockMvc.perform(MockMvcRequestBuilders.put("/studyrooms/" + studyRoomId + "/next-step")
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/studyrooms/" + studyRoomId + "/next-step")
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +


### PR DESCRIPTION
## 작업 내용
- 프론트와 같은 도메인을 사용하기 위해 백엔드 URL 앞에 /api 추가
  - 서브도메인을 사용할 필요가 없어지고, CORS, SameSite 문제가 해결됨
  
  `/studyrooms -> /api/studyrooms`