### PR TITLE
Refactor: 참가자 카운트 메서드 시그니처 변경

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/LeaveStudyService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/LeaveStudyService.java
@@ -49,7 +49,7 @@ public class LeaveStudyService {
 
         participant.delete();
 
-        Long participantCount = participantRepository.countActiveByStudyRoomId(studyRoomId);
+        Long participantCount = participantRepository.countActiveBy(studyRoomId);
 
         if (participantCount == 0) {
             completeStudyRoomService.completeStudy(studyRoomId);

--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
@@ -37,7 +37,7 @@ public class ParticipateService {
 
         studyRoom.validateIncomplete();
 
-        Long participantCount = participantRepository.countActiveByStudyRoomId(studyRoomId);
+        Long participantCount = participantRepository.countActiveBy(studyRoomId);
 
         studyRoom.validateMaxParticipantExceeded(participantCount);
 

--- a/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryImpl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryImpl.java
@@ -18,7 +18,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryQueryDsl{
     }
 
     @Override
-    public Long countActiveByStudyRoomId(StudyRoomId studyRoomId) {
+    public Long countActiveBy(StudyRoomId studyRoomId) {
         QParticipant participant = QParticipant.participant;
 
         return queryFactory
@@ -30,7 +30,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryQueryDsl{
     }
 
     @Override
-    public List<Participant> findAllActiveByStudyRoomId(StudyRoomId studyRoomId) {
+    public List<Participant> findAllActiveBy(StudyRoomId studyRoomId) {
         QParticipant participant = QParticipant.participant;
 
         return queryFactory

--- a/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryQueryDsl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryQueryDsl.java
@@ -6,7 +6,7 @@ import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import java.util.List;
 
 public interface ParticipantRepositoryQueryDsl {
-    Long countActiveByStudyRoomId(StudyRoomId studyRoomId);
+    Long countActiveBy(StudyRoomId studyRoomId);
 
-    List<Participant> findAllActiveByStudyRoomId(StudyRoomId id);
+    List<Participant> findAllActiveBy(StudyRoomId id);
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomService.java
@@ -35,7 +35,7 @@ public class GetStudyRoomService {
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
                 .orElseThrow(StudyRoomNotFoundException::new);
 
-        List<Participant> participants = participantRepository.findAllActiveByStudyRoomId(studyRoom.id());
+        List<Participant> participants = participantRepository.findAllActiveBy(studyRoom.id());
 
         List<ParticipantSummaryDto> participantSummaryDtos = participants.stream()
                 .map(Participant::toSummaryDto).toList();

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
@@ -65,7 +65,7 @@ class ParticipateServiceTest {
         given(studyRoomRepository.findById(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
-        given(participantRepository.countActiveByStudyRoomId(studyRoom.id()))
+        given(participantRepository.countActiveBy(studyRoom.id()))
                 .willReturn(1L);
 
         given(participantRepository.save(any()))
@@ -131,7 +131,7 @@ class ParticipateServiceTest {
         given(studyRoomRepository.findById(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
-        given(participantRepository.countActiveByStudyRoomId(studyRoom.id()))
+        given(participantRepository.countActiveBy(studyRoom.id()))
                 .willReturn(1L);
 
         assertThrows(StudyAlreadyCompletedException.class,
@@ -155,7 +155,7 @@ class ParticipateServiceTest {
         given(studyRoomRepository.findById(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
-        given(participantRepository.countActiveByStudyRoomId(studyRoom.id()))
+        given(participantRepository.countActiveBy(studyRoom.id()))
                 .willReturn(studyRoom.maxParticipantCount().longValue());
 
         assertThrows(MaxParticipantExceededException.class,

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomServiceTest.java
@@ -45,7 +45,7 @@ class GetStudyRoomServiceTest {
         given(studyRoomRepository.findById(studyRoomId))
                 .willReturn(Optional.of(studyRoom));
 
-        given(participantRepository.countActiveByStudyRoomId(studyRoom.id()))
+        given(participantRepository.countActiveBy(studyRoom.id()))
                 .willReturn(1L);
 
         UserId userId = UserId.of(1L);


### PR DESCRIPTION
- 가독성 향상을 위해 메서드 시그니처 변경
  - `participantRepository.countActiveByStudyRoomId(studyRoomId)` -> `participantRepository.countActiveBy(studyRoomId)`