### PR TITLE
Refactor: 다음 스터디 단계 진행을 웹소켓 기반으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// Websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/pomodoro/pomodoromate/config/WebSocketConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/config/WebSocketConfig.java
@@ -1,0 +1,41 @@
+package com.pomodoro.pomodoromate.config;
+
+import com.pomodoro.pomodoromate.websocket.WebSocketHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Value("${allow-origin}")
+    private String allowOrigin;
+
+    private final WebSocketHandler webSocketHandler;
+
+    public WebSocketConfig(WebSocketHandler webSocketHandler) {
+        this.webSocketHandler = webSocketHandler;
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/study")
+                .setAllowedOrigins(allowOrigin)
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketHandler);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressService.java
@@ -7,6 +7,7 @@ import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
 import com.pomodoro.pomodoromate.user.applications.ValidateUserService;
 import com.pomodoro.pomodoromate.user.models.UserId;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,11 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyProgressService {
     private final ValidateUserService validateUserService;
     private final StudyRoomRepository studyRoomRepository;
+    private final SimpMessagingTemplate messagingTemplate;
 
     public StudyProgressService(ValidateUserService validateUserService,
-                                StudyRoomRepository studyRoomRepository) {
+                                StudyRoomRepository studyRoomRepository,
+                                SimpMessagingTemplate messagingTemplate) {
         this.validateUserService = validateUserService;
         this.studyRoomRepository = studyRoomRepository;
+        this.messagingTemplate = messagingTemplate;
     }
 
     @Transactional
@@ -32,5 +36,10 @@ public class StudyProgressService {
         studyRoom.validateIncomplete();
 
         studyRoom.proceedToNextStep();
+
+        messagingTemplate.convertAndSend(
+                "/sub/studyrooms/" + studyRoomId.value() + "/next-step",
+                studyRoom.toNextStepDto()
+        );
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
@@ -16,11 +16,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -85,16 +90,15 @@ public class StudyRoomController {
     }
 
     @Operation(summary = "다음 스터디 단계 진행")
-    @ApiResponse(responseCode = "204")
-    @PutMapping("{studyRoomId}/next-step")
-    public ResponseEntity<Void> proceedToNextStep(
-            @RequestAttribute UserId userId,
-            @PathVariable Long studyRoomId,
-            @Validated @RequestBody StudyProgressRequestDto requestDto
+    @MessageMapping("{studyRoomId}/next-step")
+    public void proceedToNextStep(
+            @DestinationVariable Long studyRoomId,
+            @Payload StudyProgressRequestDto requestDto,
+            SimpMessageHeaderAccessor headerAccessor
     ) {
+        UserId userId = (UserId) headerAccessor.getSessionAttributes().get("UserId");
+
         studyProgressService.proceedToNextStep(
                 userId, StudyRoomId.of(studyRoomId), Step.valueOf(requestDto.step()));
-
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/NextStepStudyRoomDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/NextStepStudyRoomDto.java
@@ -1,0 +1,7 @@
+package com.pomodoro.pomodoromate.studyRoom.dtos;
+
+import java.time.LocalDateTime;
+
+public record NextStepStudyRoomDto(
+        Long id, String step, LocalDateTime updateAt) {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoom.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/models/StudyRoom.java
@@ -2,6 +2,7 @@ package com.pomodoro.pomodoromate.studyRoom.models;
 
 import com.pomodoro.pomodoromate.common.models.BaseEntity;
 import com.pomodoro.pomodoromate.participant.dtos.ParticipantSummaryDto;
+import com.pomodoro.pomodoromate.studyRoom.dtos.NextStepStudyRoomDto;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomDetailDto;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.InvalidStepException;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.MaxParticipantExceededException;
@@ -129,5 +130,9 @@ public class StudyRoom extends BaseEntity {
 
     public Integer maxParticipantCount() {
         return maxParticipantCount.value();
+    }
+
+    public NextStepStudyRoomDto toNextStepDto() {
+        return new NextStepStudyRoomDto(id, step.toString(), updateAt());
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
+++ b/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
@@ -1,0 +1,60 @@
+package com.pomodoro.pomodoromate.websocket;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.pomodoro.pomodoromate.auth.exceptions.AuthenticationError;
+import com.pomodoro.pomodoromate.auth.utils.JwtUtil;
+import com.pomodoro.pomodoromate.user.models.UserId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class WebSocketHandler implements ChannelInterceptor {
+    private JwtUtil jwtUtil;
+
+    public WebSocketHandler(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if(accessor.getCommand() == StompCommand.SUBSCRIBE) {
+            log.info("[web socket] - preSend 메서드 /connect / 시작");
+
+            String authorization = accessor.getFirstNativeHeader("Authorization");
+            log.info("authorization: " + authorization);
+
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+                throw new AuthenticationError();
+            }
+
+            String accessToken = authorization.substring("Bearer ".length());
+
+            try {
+                UserId userId = jwtUtil.decode(accessToken);
+                log.info("userId: " + userId.value());
+
+                Map<String, Object> attributes = accessor.getSessionAttributes();
+                attributes.put("UserId", userId);
+                accessor.setSessionAttributes(attributes);
+
+                log.info("[web socket] - preSend 메서드 / connect / 완료");
+
+                return message;
+            } catch (JWTDecodeException exception) {
+                throw new AuthenticationError();
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
@@ -156,21 +156,4 @@ class StudyRoomControllerTest {
                         "\"id\":1"
                 )));
     }
-
-    @Test
-    void proceedToNextStep() throws Exception {
-        UserId userId = new UserId(1L);
-
-        String token = jwtUtil.encode(userId);
-
-        Long studyRoomId = 1L;
-
-        mockMvc.perform(MockMvcRequestBuilders.put("/api/studyrooms/" + studyRoomId + "/next-step")
-                        .header("Authorization", "Bearer " + token)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{" +
-                                "   \"step\": \"PLANNING\"" +
-                                "}"))
-                .andExpect(status().isNoContent());
-    }
 }


### PR DESCRIPTION
## 작업 내용
- 실시간으로 스터디 진행 상태를 업데이트하고, 클라이언트에게 상태를 전달할 수 있게 하기 위해 다음 스터디 단계 진행을 웹소켓 기반으로 변경
  - StudyProgressService 클래스의 proceedToNextStep 메서드를 웹소켓 메시지 핸들러로 변경하여 스터디 단계 진행 처리
