### PR TITLE
Refactor: Post 요청으로 새 리소스를 생성했을 때, 응답으로 Body를 통해 Id를 전달하도록 변경

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
@@ -2,11 +2,13 @@ package com.pomodoro.pomodoromate.participant.cotrollers;
 
 import com.pomodoro.pomodoromate.participant.applications.LeaveStudyService;
 import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
+import com.pomodoro.pomodoromate.participant.dtos.ParticipateResponseDto;
 import com.pomodoro.pomodoromate.participant.models.ParticipantId;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.pomodoro.pomodoromate.user.models.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,14 +33,14 @@ public class ParticipantController {
     @Operation(summary = "스터디 참가")
     @ApiResponse(responseCode = "201")
     @PostMapping("studyrooms/{studyRoomId}/participants")
-    public ResponseEntity<Void> participate(
+    public ResponseEntity<ParticipateResponseDto> participate(
             @RequestAttribute UserId userId,
             @PathVariable Long studyRoomId
     ) {
         Long participantId = participateService.participate(userId, StudyRoomId.of(studyRoomId));
 
-        return ResponseEntity.created(
-                URI.create("/studyrooms/" + studyRoomId + "/participants/" + participantId)).build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ParticipateResponseDto(participantId));
     }
 
     @Operation(summary = "스터디 나가기")

--- a/src/main/java/com/pomodoro/pomodoromate/participant/dtos/ParticipateResponseDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/dtos/ParticipateResponseDto.java
@@ -1,0 +1,6 @@
+package com.pomodoro.pomodoromate.participant.dtos;
+
+public record ParticipateResponseDto(
+        Long id
+) {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
@@ -6,6 +6,7 @@ import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomsService;
 import com.pomodoro.pomodoromate.studyRoom.applications.StudyProgressService;
 import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
 import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequestDto;
+import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomResponseDto;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyProgressRequestDto;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomDetailDto;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomSummariesDto;
@@ -15,10 +16,9 @@ import com.pomodoro.pomodoromate.user.models.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -31,8 +31,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
 
 @Tag(name = "스터디룸 API")
 @RestController
@@ -78,7 +76,7 @@ public class StudyRoomController {
     @Operation(summary = "스터디룸 생성")
     @ApiResponse(responseCode = "201")
     @PostMapping
-    public ResponseEntity<Void> create(
+    public ResponseEntity<CreateStudyRoomResponseDto> create(
             @RequestAttribute UserId userId,
             @Validated @RequestBody CreateStudyRoomRequestDto requestDto
     ) {
@@ -86,7 +84,8 @@ public class StudyRoomController {
 
         Long studyRoomId = createStudyRoomService.create(request, userId);
 
-        return ResponseEntity.created(URI.create("/studyrooms/" + studyRoomId)).build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateStudyRoomResponseDto(studyRoomId));
     }
 
     @Operation(summary = "다음 스터디 단계 진행")

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomResponseDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomResponseDto.java
@@ -1,0 +1,6 @@
+package com.pomodoro.pomodoromate.studyRoom.dtos;
+
+public record CreateStudyRoomResponseDto(
+        Long id
+) {
+}


### PR DESCRIPTION
## 작업 내용
- Post API에서 응답을 작성할 때 URI location 대신 DTO를 직접 사용하여 ResponseEntity를 생성하도록 변경