### PR TITLE
Feat: 스터디 참가 및 나가기 API에 웹소켓을 통한 참가자 목록 전송 기능 추가

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/GetParticipantsService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/GetParticipantsService.java
@@ -1,0 +1,26 @@
+package com.pomodoro.pomodoromate.participant.applications;
+
+import com.pomodoro.pomodoromate.participant.models.Participant;
+import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class GetParticipantsService {
+    private final ParticipantRepository participantRepository;
+
+    public GetParticipantsService(ParticipantRepository participantRepository) {
+        this.participantRepository = participantRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ParticipantSummariesDto activeParticipants(StudyRoomId studyRoomId) {
+        List<Participant> participants = participantRepository.findAllActiveBy(studyRoomId);
+
+        return new ParticipantSummariesDto(participants.stream()
+                .map(Participant::toSummaryDto).toList());
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipantSummariesDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipantSummariesDto.java
@@ -1,0 +1,10 @@
+package com.pomodoro.pomodoromate.participant.applications;
+
+import com.pomodoro.pomodoromate.participant.dtos.ParticipantSummaryDto;
+
+import java.util.List;
+
+public record ParticipantSummariesDto(
+        List<ParticipantSummaryDto> participantSummaries
+) {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantController.java
@@ -1,6 +1,8 @@
 package com.pomodoro.pomodoromate.participant.cotrollers;
 
+import com.pomodoro.pomodoromate.participant.applications.GetParticipantsService;
 import com.pomodoro.pomodoromate.participant.applications.LeaveStudyService;
+import com.pomodoro.pomodoromate.participant.applications.ParticipantSummariesDto;
 import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
 import com.pomodoro.pomodoromate.participant.dtos.ParticipateResponseDto;
 import com.pomodoro.pomodoromate.participant.models.ParticipantId;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,17 +20,23 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 
 @RestController
 @RequestMapping("api")
 public class ParticipantController {
     private final ParticipateService participateService;
     private final LeaveStudyService leaveStudyService;
+    private final GetParticipantsService getParticipantsService;
+    private final SimpMessagingTemplate messagingTemplate;
 
-    public ParticipantController(ParticipateService participateService, LeaveStudyService leaveStudyService) {
+    public ParticipantController(ParticipateService participateService,
+                                 LeaveStudyService leaveStudyService,
+                                 GetParticipantsService getParticipantsService,
+                                 SimpMessagingTemplate messagingTemplate) {
         this.participateService = participateService;
         this.leaveStudyService = leaveStudyService;
+        this.getParticipantsService = getParticipantsService;
+        this.messagingTemplate = messagingTemplate;
     }
 
     @Operation(summary = "스터디 참가")
@@ -38,6 +47,12 @@ public class ParticipantController {
             @PathVariable Long studyRoomId
     ) {
         Long participantId = participateService.participate(userId, StudyRoomId.of(studyRoomId));
+
+        ParticipantSummariesDto participantSummariesDto = getParticipantsService
+                .activeParticipants(StudyRoomId.of(studyRoomId));
+
+        messagingTemplate.convertAndSend("/sub/studyrooms/" + studyRoomId + "/participants"
+                , participantSummariesDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ParticipateResponseDto(participantId));
@@ -50,8 +65,14 @@ public class ParticipantController {
             @RequestAttribute UserId userId,
             @PathVariable Long studyRoomId,
             @PathVariable Long participantId
-            ) {
+    ) {
         leaveStudyService.leaveStudy(userId, StudyRoomId.of(studyRoomId), ParticipantId.of(participantId));
+
+        ParticipantSummariesDto participantSummariesDto = getParticipantsService
+                .activeParticipants(StudyRoomId.of(studyRoomId));
+
+        messagingTemplate.convertAndSend("/sub/studyrooms/" + studyRoomId + "/participants"
+                , participantSummariesDto);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/GetParticipantsServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/GetParticipantsServiceTest.java
@@ -1,0 +1,54 @@
+package com.pomodoro.pomodoromate.participant.applications;
+
+import com.pomodoro.pomodoromate.participant.dtos.ParticipantSummaryDto;
+import com.pomodoro.pomodoromate.participant.models.Participant;
+import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
+import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomService;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import com.pomodoro.pomodoromate.user.applications.ValidateUserService;
+import com.pomodoro.pomodoromate.user.models.UserId;
+import com.pomodoro.pomodoromate.user.models.UserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetParticipantsServiceTest {
+    private ParticipantRepository participantRepository;
+    private GetParticipantsService getParticipantsService;
+
+    @BeforeEach
+    void setUp() {
+        participantRepository = mock(ParticipantRepository.class);
+        getParticipantsService = new GetParticipantsService(participantRepository);
+    }
+
+    @Test
+    void activeParticipants() {
+        StudyRoomId studyRoomId = StudyRoomId.of(1L);
+        UserId userId = UserId.of(1L);
+
+        Participant participant = Participant.builder()
+                .id(1L)
+                .studyRoomId(studyRoomId)
+                .userId(userId)
+                .userInfo(new UserInfo())
+                .build();
+
+        given(participantRepository.findAllActiveBy(studyRoomId))
+                .willReturn(List.of(participant));
+
+        ParticipantSummariesDto participantSummariesDto = getParticipantsService
+                .activeParticipants(studyRoomId);
+
+        assertThat(participantSummariesDto.participantSummaries())
+                .hasSize(1);
+        assertThat(participantSummariesDto.participantSummaries().get(0).userId())
+                .isEqualTo(userId.value());
+    }
+}

--- a/src/test/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/cotrollers/ParticipantControllerTest.java
@@ -1,12 +1,11 @@
 package com.pomodoro.pomodoromate.participant.cotrollers;
 
 import com.pomodoro.pomodoromate.auth.config.JwtConfig;
-import com.pomodoro.pomodoromate.auth.exceptions.UnauthorizedException;
 import com.pomodoro.pomodoromate.auth.utils.JwtUtil;
 import com.pomodoro.pomodoromate.config.SecurityConfig;
+import com.pomodoro.pomodoromate.participant.applications.GetParticipantsService;
 import com.pomodoro.pomodoromate.participant.applications.LeaveStudyService;
 import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
-import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNotFoundException;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.pomodoro.pomodoromate.user.models.UserId;
 import org.junit.jupiter.api.Test;
@@ -15,10 +14,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,6 +32,12 @@ class ParticipantControllerTest {
 
     @MockBean
     private LeaveStudyService leaveStudyService;
+
+    @MockBean
+    private GetParticipantsService getParticipantsService;
+
+    @MockBean
+    private SimpMessagingTemplate messagingTemplate;
 
     @SpyBean
     private JwtUtil jwtUtil;

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/GetStudyRoomServiceTest.java
@@ -1,5 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.applications;
 
+import com.pomodoro.pomodoromate.participant.models.Participant;
 import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomDetailDto;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNotFoundException;
@@ -7,10 +8,13 @@ import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomInfo;
 import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
 import com.pomodoro.pomodoromate.user.applications.ValidateUserService;
+import com.pomodoro.pomodoromate.user.models.User;
 import com.pomodoro.pomodoromate.user.models.UserId;
+import com.pomodoro.pomodoromate.user.models.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,16 +41,28 @@ class GetStudyRoomServiceTest {
     void studyRoom() {
         Long studyRoomId = 1L;
 
+        User user = User.builder()
+                .id(1L)
+                .info(new UserInfo())
+                .build();
+
         StudyRoom studyRoom = StudyRoom.builder()
                 .id(studyRoomId)
                 .info(new StudyRoomInfo("스터디방 1", "설명"))
                 .build();
 
+        Participant participant = Participant.builder()
+                .id(1L)
+                .studyRoomId(studyRoom.id())
+                .userId(user.id())
+                .userInfo(user.info())
+                .build();
+
         given(studyRoomRepository.findById(studyRoomId))
                 .willReturn(Optional.of(studyRoom));
 
-        given(participantRepository.countActiveBy(studyRoom.id()))
-                .willReturn(1L);
+        given(participantRepository.findAllActiveBy(studyRoom.id()))
+                .willReturn(List.of(participant));
 
         UserId userId = UserId.of(1L);
 


### PR DESCRIPTION
## 작업 내용
- ParticipantController 클래스의 participate 및 leaveStudy 메서드에 실시간 업데이트 기능 추가
- 스터디 참가 또는 나가기 요청 완료 시 해당 스터디룸의 활성 참가자 목록을 가져와서 처리
- messagingTemplate을 활용하여 웹 소켓을 통해 클라이언트에게 업데이트된 참가자 목록 전송
- 클라이언트는 이를 통해 실시간으로 스터디룸의 참가자 목록을 업데이트할 수 있음