### PR TITLE
Feat: 웹소켓 연결 종료 시, 스터디 나감 처리

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/common/models/SessionId.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/models/SessionId.java
@@ -1,0 +1,27 @@
+package com.pomodoro.pomodoromate.common.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionId {
+    @Column(name = "sessionId")
+    private String value;
+
+    public SessionId(String value) {
+        this.value = value;
+    }
+
+    public static SessionId of(String sessionId) {
+        return new SessionId(sessionId);
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
@@ -13,6 +13,8 @@ import com.pomodoro.pomodoromate.user.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class ParticipateService {
     private final ParticipantRepository participantRepository;
@@ -40,6 +42,12 @@ public class ParticipateService {
         Long participantCount = participantRepository.countActiveBy(studyRoomId);
 
         studyRoom.validateMaxParticipantExceeded(participantCount);
+
+        Optional<Participant> existingParticipant = participantRepository.findBy(userId, studyRoomId);
+
+        if (existingParticipant.isPresent()) {
+            return existingParticipant.get().id().value();
+        }
 
         Participant participant = Participant.builder()
                 .studyRoomId(studyRoom.id())

--- a/src/main/java/com/pomodoro/pomodoromate/participant/models/Participant.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/models/Participant.java
@@ -2,6 +2,7 @@ package com.pomodoro.pomodoromate.participant.models;
 
 import com.pomodoro.pomodoromate.common.exceptions.AuthorizationException;
 import com.pomodoro.pomodoromate.common.models.BaseEntity;
+import com.pomodoro.pomodoromate.common.models.SessionId;
 import com.pomodoro.pomodoromate.common.models.Status;
 import com.pomodoro.pomodoromate.participant.dtos.ParticipantSummaryDto;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomMismatchException;
@@ -16,9 +17,12 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant extends BaseEntity {
     @Id
     @GeneratedValue
@@ -35,11 +39,11 @@ public class Participant extends BaseEntity {
     @Embedded
     private UserInfo userInfo;
 
+    @Embedded
+    private SessionId sessionId;
+
     @Enumerated(EnumType.STRING)
     private Status status;
-
-    public Participant() {
-    }
 
     @Builder
     public Participant(Long id, StudyRoomId studyRoomId, UserId userId, UserInfo userInfo) {
@@ -89,5 +93,10 @@ public class Participant extends BaseEntity {
     public ParticipantSummaryDto toSummaryDto() {
         return new ParticipantSummaryDto(id, userId.value(),
                 userInfo.nickname(), userInfo.imageUrl());
+    }
+
+    public void activate(SessionId sessionId) {
+        this.sessionId = sessionId;
+        this.status = Status.ACTIVE;
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepository.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepository.java
@@ -3,5 +3,8 @@ package com.pomodoro.pomodoromate.participant.repositories;
 import com.pomodoro.pomodoromate.participant.models.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long>, ParticipantRepositoryQueryDsl {
+    Optional<Participant> findBySessionId(String sessionId);
 }

--- a/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryImpl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryImpl.java
@@ -4,10 +4,12 @@ import com.pomodoro.pomodoromate.common.models.Status;
 import com.pomodoro.pomodoromate.participant.models.Participant;
 import com.pomodoro.pomodoromate.participant.models.QParticipant;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import com.pomodoro.pomodoromate.user.models.UserId;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class ParticipantRepositoryImpl implements ParticipantRepositoryQueryDsl{
@@ -39,5 +41,16 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryQueryDsl{
                 .where(participant.studyRoomId.eq(studyRoomId).and(
                         participant.status.eq(Status.ACTIVE)))
                 .fetch();
+    }
+
+    @Override
+    public Optional<Participant> findBy(UserId userId, StudyRoomId studyRoomId) {
+        QParticipant participant = QParticipant.participant;
+
+        return Optional.ofNullable(queryFactory
+                .selectFrom(participant)
+                .where(participant.studyRoomId.eq(studyRoomId).and(
+                        participant.userId.eq(userId)))
+                .fetchOne());
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryQueryDsl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/repositories/ParticipantRepositoryQueryDsl.java
@@ -2,11 +2,15 @@ package com.pomodoro.pomodoromate.participant.repositories;
 
 import com.pomodoro.pomodoromate.participant.models.Participant;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import com.pomodoro.pomodoromate.user.models.UserId;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ParticipantRepositoryQueryDsl {
     Long countActiveBy(StudyRoomId studyRoomId);
 
     List<Participant> findAllActiveBy(StudyRoomId id);
+
+    Optional<Participant> findBy(UserId userId, StudyRoomId studyRoomId);
 }

--- a/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
+++ b/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
@@ -3,6 +3,14 @@ package com.pomodoro.pomodoromate.websocket;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.pomodoro.pomodoromate.auth.exceptions.AuthenticationError;
 import com.pomodoro.pomodoromate.auth.utils.JwtUtil;
+import com.pomodoro.pomodoromate.common.models.SessionId;
+import com.pomodoro.pomodoromate.participant.exceptions.ParticipantNotFoundException;
+import com.pomodoro.pomodoromate.participant.models.Participant;
+import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
+import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNotFoundException;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
+import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
 import com.pomodoro.pomodoromate.user.models.UserId;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -17,10 +25,19 @@ import java.util.Map;
 @Slf4j
 @Component
 public class WebSocketHandler implements ChannelInterceptor {
-    private JwtUtil jwtUtil;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String STUDY_ROOM_ID_HEADER = "studyRoomId";
 
-    public WebSocketHandler(JwtUtil jwtUtil) {
+    private final JwtUtil jwtUtil;
+    private final ParticipantRepository participantRepository;
+    private final StudyRoomRepository studyRoomRepository;
+
+    public WebSocketHandler(JwtUtil jwtUtil,
+                            ParticipantRepository participantRepository,
+                            StudyRoomRepository studyRoomRepository) {
         this.jwtUtil = jwtUtil;
+        this.participantRepository = participantRepository;
+        this.studyRoomRepository = studyRoomRepository;
     }
 
     @Override
@@ -28,33 +45,69 @@ public class WebSocketHandler implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
         if(accessor.getCommand() == StompCommand.SUBSCRIBE) {
-            log.info("[web socket] - preSend 메서드 /connect / 시작");
+            handleSubscribeMessage(accessor);
+        }
 
-            String authorization = accessor.getFirstNativeHeader("Authorization");
-            log.info("authorization: " + authorization);
-
-            if (authorization == null || !authorization.startsWith("Bearer ")) {
-                throw new AuthenticationError();
-            }
-
-            String accessToken = authorization.substring("Bearer ".length());
-
-            try {
-                UserId userId = jwtUtil.decode(accessToken);
-                log.info("userId: " + userId.value());
-
-                Map<String, Object> attributes = accessor.getSessionAttributes();
-                attributes.put("UserId", userId);
-                accessor.setSessionAttributes(attributes);
-
-                log.info("[web socket] - preSend 메서드 / connect / 완료");
-
-                return message;
-            } catch (JWTDecodeException exception) {
-                throw new AuthenticationError();
-            }
+        if (accessor.getCommand() == StompCommand.DISCONNECT) {
+            handleDisconnectMessage(accessor);
         }
 
         return message;
+    }
+
+    private void handleSubscribeMessage(StompHeaderAccessor accessor) {
+        log.info("[web socket] - preSend 메서드 /connect / 시작");
+
+        String authorization = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+        log.info("authorization: " + authorization);
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new AuthenticationError();
+        }
+
+        String accessToken = authorization.substring("Bearer ".length());
+
+        try {
+            UserId userId = jwtUtil.decode(accessToken);
+            log.info("userId: " + userId.value());
+
+            Long studyRoomId = Long.valueOf(accessor.getFirstNativeHeader(STUDY_ROOM_ID_HEADER));
+            log.info("studyRoomId: " + studyRoomId);
+
+            StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
+                    .orElseThrow(StudyRoomNotFoundException::new);
+
+            studyRoom.validateIncomplete();
+
+            Map<String, Object> attributes = accessor.getSessionAttributes();
+            attributes.put("UserId", userId);
+            accessor.setSessionAttributes(attributes);
+
+            String sessionId = accessor.getSessionId();
+            log.info("sessionId: " + sessionId);
+
+            Participant participant = participantRepository.findBy(userId, StudyRoomId.of(studyRoomId))
+                    .orElseThrow(ParticipantNotFoundException::new);
+
+            participant.activate(SessionId.of(sessionId));
+
+            log.info("[web socket] - preSend 메서드 / connect / 완료");
+        } catch (JWTDecodeException exception) {
+            throw new AuthenticationError();
+        }
+    }
+
+    private void handleDisconnectMessage(StompHeaderAccessor accessor) {
+        log.info("[web socket] - preSend 메서드 / disconnect / 시작");
+
+        String sessionId = accessor.getSessionId();
+        log.info("sessionId: " + sessionId);
+
+        Participant participant = participantRepository.findBySessionId(sessionId)
+                .orElseThrow(ParticipantNotFoundException::new);
+
+        participant.delete();
+
+        log.info("[web socket] - preSend 메서드 / disconnect / 끝");
     }
 }


### PR DESCRIPTION
## 작업 내용
- 웹소켓 연결이 종료될 때마다 해당 사용자를 스터디에서 나간 것으로 처리
- WebSocketHandler 클래스의 preSend 메서드에서 DISCONNECT 명령을 처리하는 핸들러를 구현
  - 사용자의 세션 ID를 추출하고, 이를 사용하여 해당 사용자를 찾아 스터디에서 제거