### PR TITLE
Feat: StudyProgressService에 참가자 참여 여부 확인 기능 추가

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/participant/exceptions/ParticipantNotInRoomException.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/exceptions/ParticipantNotInRoomException.java
@@ -1,0 +1,10 @@
+package com.pomodoro.pomodoromate.participant.exceptions;
+
+import com.pomodoro.pomodoromate.common.exceptions.CustomizedException;
+import org.springframework.http.HttpStatus;
+
+public class ParticipantNotInRoomException extends CustomizedException {
+    public ParticipantNotInRoomException() {
+        super(HttpStatus.FORBIDDEN, "참가자가 현재 채팅방에 참가하지 않은 상태입니다.");
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/models/Participant.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/models/Participant.java
@@ -5,6 +5,7 @@ import com.pomodoro.pomodoromate.common.models.BaseEntity;
 import com.pomodoro.pomodoromate.common.models.SessionId;
 import com.pomodoro.pomodoromate.common.models.Status;
 import com.pomodoro.pomodoromate.participant.dtos.ParticipantSummaryDto;
+import com.pomodoro.pomodoromate.participant.exceptions.ParticipantNotInRoomException;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomMismatchException;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.pomodoro.pomodoromate.user.models.UserId;
@@ -106,5 +107,15 @@ public class Participant extends BaseEntity {
 
     public void activate() {
         this.status = Status.ACTIVE;
+    }
+
+    public void validateActive() {
+        if (!isActive()) {
+            throw new ParticipantNotInRoomException();
+        }
+    }
+
+    private boolean isActive() {
+        return this.status.equals(Status.ACTIVE);
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressService.java
@@ -1,5 +1,8 @@
 package com.pomodoro.pomodoromate.studyRoom.applications;
 
+import com.pomodoro.pomodoromate.participant.exceptions.ParticipantNotFoundException;
+import com.pomodoro.pomodoromate.participant.models.Participant;
+import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
 import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyRoomNotFoundException;
 import com.pomodoro.pomodoromate.studyRoom.models.Step;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
@@ -15,13 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyProgressService {
     private final ValidateUserService validateUserService;
     private final StudyRoomRepository studyRoomRepository;
+    private final ParticipantRepository participantRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
     public StudyProgressService(ValidateUserService validateUserService,
                                 StudyRoomRepository studyRoomRepository,
+                                ParticipantRepository participantRepository,
                                 SimpMessagingTemplate messagingTemplate) {
         this.validateUserService = validateUserService;
         this.studyRoomRepository = studyRoomRepository;
+        this.participantRepository = participantRepository;
         this.messagingTemplate = messagingTemplate;
     }
 
@@ -31,6 +37,11 @@ public class StudyProgressService {
 
         StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId.value())
                 .orElseThrow(StudyRoomNotFoundException::new);
+
+        Participant participant = participantRepository.findBy(userId, studyRoomId)
+                        .orElseThrow(ParticipantNotFoundException::new);
+
+        participant.validateActive();
 
         studyRoom.validateCurrentStep(step);
         studyRoom.validateIncomplete();


### PR DESCRIPTION
- StudyProgressService 클래스에 참가자가 현재 활성 상태인지 확인하는 validateActive() 메서드를 추가
- 해당 메서드를 통해 활성 상태가 아닌 참가자일 경우 ParticipantNotInRoomException을 발생시키도록 처리
- proceedToNextStep() 메서드 내에서 참가자의 활성 여부를 확인하여 유효성 검사를 수행하도록 변경