### PR TITLE
Feat: 웹소켓 예외처리를 위해 WebSocketErrorHandler 구현

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketErrorHandler.java
+++ b/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketErrorHandler.java
@@ -1,0 +1,55 @@
+package com.pomodoro.pomodoromate.websocket;
+
+import com.pomodoro.pomodoromate.auth.exceptions.AccessTokenExpiredException;
+import com.pomodoro.pomodoromate.auth.exceptions.TokenDecodingFailedException;
+import com.pomodoro.pomodoromate.common.exceptions.CustomizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class WebSocketErrorHandler extends StompSubProtocolErrorHandler {
+    public WebSocketErrorHandler() {
+        super();
+    }
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable exception) {
+        log.info("[web socket error handler] - handleClientMessageProcessingError 메서드");
+
+        log.info("exception: " + exception.getMessage());
+
+        if (exception.getCause().getMessage().equals(new AccessTokenExpiredException().message())) {
+            log.info("예외 내용 = {}", exception.getMessage());
+            return handleCustomizedException(new AccessTokenExpiredException());
+        }
+
+        if (exception.getCause().getMessage().equals(new TokenDecodingFailedException().message())) {
+            log.info("예외 내용 = {}", exception.getMessage());
+            return handleCustomizedException(new TokenDecodingFailedException());
+        }
+
+        log.info("예외 내용 = {}", exception.getMessage());
+        return super.handleClientMessageProcessingError(clientMessage, exception);
+    }
+
+    private Message<byte[]> handleCustomizedException(CustomizedException exception) {
+        String message = exception.getMessage();
+        log.info("exception message: " + exception.getMessage());
+        log.info("exception code: " + exception.statusCode().value());
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+
+        accessor.setMessage(String.valueOf(exception.statusCode().value()));
+        accessor.setLeaveMutable(true);
+
+        return MessageBuilder.createMessage(message.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
+++ b/src/main/java/com/pomodoro/pomodoromate/websocket/WebSocketHandler.java
@@ -1,7 +1,9 @@
 package com.pomodoro.pomodoromate.websocket;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.pomodoro.pomodoromate.auth.exceptions.AccessTokenExpiredException;
 import com.pomodoro.pomodoromate.auth.exceptions.AuthenticationError;
+import com.pomodoro.pomodoromate.auth.exceptions.TokenDecodingFailedException;
 import com.pomodoro.pomodoromate.auth.utils.JwtUtil;
 import com.pomodoro.pomodoromate.common.models.SessionId;
 import com.pomodoro.pomodoromate.participant.applications.GetParticipantsService;
@@ -105,8 +107,10 @@ public class WebSocketHandler implements ChannelInterceptor {
             participantRepository.save(participant);
 
             log.info("[web socket] - preSend 메서드 / connect / 완료");
-        } catch (JWTDecodeException exception) {
-            throw new AuthenticationError();
+        } catch (AccessTokenExpiredException
+                 | TokenDecodingFailedException exception
+        ) {
+            throw exception;
         }
     }
 

--- a/src/main/java/com/pomodoro/pomodoromate/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/websocket/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
-package com.pomodoro.pomodoromate.config;
+package com.pomodoro.pomodoromate.websocket.config;
 
+import com.pomodoro.pomodoromate.websocket.WebSocketErrorHandler;
 import com.pomodoro.pomodoromate.websocket.WebSocketHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -16,9 +17,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private String[] allowOrigins;
 
     private final WebSocketHandler webSocketHandler;
+    private final WebSocketErrorHandler webSocketErrorHandler;
 
-    public WebSocketConfig(WebSocketHandler webSocketHandler) {
+    public WebSocketConfig(WebSocketHandler webSocketHandler, WebSocketErrorHandler webSocketErrorHandler) {
         this.webSocketHandler = webSocketHandler;
+        this.webSocketErrorHandler = webSocketErrorHandler;
     }
 
     @Override
@@ -26,6 +29,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/study")
                 .setAllowedOrigins(allowOrigins)
                 .withSockJS();
+
+        registry.setErrorHandler(webSocketErrorHandler);
     }
 
     @Override


### PR DESCRIPTION
- ErrorHandler 구현
  - 소켓 통신 중, 예외가 발생했을 때, “WebSocketErrorHandler”로 제어권이 넘어감
  - WebSocketErrorHandler에서 handleClientMessageProcessingError 메서드를 통해 에러메시지를 보내도록 함