### PR TITLE
Feat: 동시성 제어를 위해 participate에 synchronized 적용

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
@@ -30,7 +30,7 @@ public class ParticipateService {
     }
 
     @Transactional
-    public Long participate(UserId userId, StudyRoomId studyRoomId) {
+    public synchronized Long participate(UserId userId, StudyRoomId studyRoomId) {
         User user = userRepository.findById(userId.value())
                 .orElseThrow(UnauthorizedException::new);
 
@@ -43,6 +43,10 @@ public class ParticipateService {
 
         studyRoom.validateMaxParticipantExceeded(participantCount);
 
+        return createOrUpdateParticipant(userId, studyRoomId, user, studyRoom);
+    }
+
+    private Long createOrUpdateParticipant(UserId userId, StudyRoomId studyRoomId, User user, StudyRoom studyRoom) {
         Optional<Participant> existingParticipant = participantRepository.findBy(userId, studyRoomId);
 
         if (existingParticipant.isPresent()) {

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceIntegrationTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.pomodoro.pomodoromate.participant.applications;
+
+import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;
+import com.pomodoro.pomodoromate.studyRoom.models.MaxParticipantCount;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
+import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
+import com.pomodoro.pomodoromate.user.models.User;
+import com.pomodoro.pomodoromate.user.models.UserId;
+import com.pomodoro.pomodoromate.user.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ParticipateServiceIntegrationTest {
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRoomRepository studyRoomRepository;
+
+    @Autowired
+    private ParticipateService participateService;
+
+    @Test
+    void participateWith() throws InterruptedException {
+        int requestCount = 10;
+
+        StudyRoom studyRoom = StudyRoom.builder()
+                .id(1000L)
+                .maxParticipantCount(MaxParticipantCount.of(8))
+                .build();
+
+        studyRoomRepository.save(studyRoom);
+
+        for (int i = 1; i <= requestCount; i += 1) {
+            User user = User.builder()
+                    .id((long) i)
+                    .build();
+
+            userRepository.save(user);
+        }
+
+        int threadCount = 10;
+
+        // thread 사용할 수 있는 서비스 선언, 몇 개의 스레드 사용할건지 지정
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        // 다른 스레드 작업 완료까지 기다리게 해주는 클래스
+        // 몇을 카운트할지 지정
+        // countDown()을 통해 0까지 세어야 await()하던 thread가 다시 실행됨
+        CountDownLatch latch = new CountDownLatch(requestCount);
+
+        for (int i = 1; i <= requestCount; i += 1) {
+            UserId userId = UserId.of((long) i);
+            executorService.submit(() -> {
+                try {
+                    participateService.participate(userId, studyRoom.id());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Long participantCount = participantRepository.countActiveBy(studyRoom.id());
+
+        assertThat(participantCount).isEqualTo(8L);
+    }
+}

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
- 스터디 참가자가 최대 인원수를 넘기지 않도록 않도록 동시성 제어
  - ParticipateService의 participate(스터디 참가)에 synchronized 적용