### PR TITLE
Chore: 스터디룸 생성 시, 응답값에 참가자 id도 포함하도록 변경

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomService.java
@@ -1,6 +1,5 @@
 package com.pomodoro.pomodoromate.studyRoom.applications;
 
-import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
 import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
 import com.pomodoro.pomodoromate.studyRoom.models.MaxParticipantCount;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
@@ -15,16 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateStudyRoomService {
     private final StudyRoomRepository studyRoomRepository;
     private final ValidateUserService validateUserService;
-    private final ParticipateService participateService;
     private final PasswordEncoder passwordEncoder;
 
     public CreateStudyRoomService(StudyRoomRepository studyRoomRepository,
                                   ValidateUserService validateUserService,
-                                  ParticipateService participateService,
                                   PasswordEncoder passwordEncoder) {
         this.studyRoomRepository = studyRoomRepository;
         this.validateUserService = validateUserService;
-        this.participateService = participateService;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -43,8 +39,6 @@ public class CreateStudyRoomService {
 //        }
 
         StudyRoom saved = studyRoomRepository.save(studyRoom);
-
-        participateService.participate(userId, studyRoom.id());
 
         return saved.id().value();
     }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomController.java
@@ -1,5 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.controllers;
 
+import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
 import com.pomodoro.pomodoromate.studyRoom.applications.CreateStudyRoomService;
 import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomService;
 import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomsService;
@@ -38,15 +39,18 @@ public class StudyRoomController {
     private final GetStudyRoomsService getStudyRoomsService;
     private final GetStudyRoomService getStudyRoomService;
     private final StudyProgressService studyProgressService;
+    private final ParticipateService participateService;
 
     public StudyRoomController(CreateStudyRoomService createStudyRoomService,
                                GetStudyRoomsService getStudyRoomsService,
                                GetStudyRoomService getStudyRoomService,
-                               StudyProgressService studyProgressService) {
+                               StudyProgressService studyProgressService,
+                               ParticipateService participateService) {
         this.createStudyRoomService = createStudyRoomService;
         this.getStudyRoomsService = getStudyRoomsService;
         this.getStudyRoomService = getStudyRoomService;
         this.studyProgressService = studyProgressService;
+        this.participateService = participateService;
     }
 
     @Operation(summary = "스터디룸 목록 조회")
@@ -82,8 +86,10 @@ public class StudyRoomController {
 
         Long studyRoomId = createStudyRoomService.create(request, userId);
 
+        Long participateId = participateService.participate(userId, StudyRoomId.of(studyRoomId));
+
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CreateStudyRoomResponseDto(studyRoomId));
+                .body(new CreateStudyRoomResponseDto(studyRoomId, participateId));
     }
 
     @Operation(summary = "다음 스터디 단계 진행")

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomResponseDto.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/dtos/CreateStudyRoomResponseDto.java
@@ -1,6 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.dtos;
 
 public record CreateStudyRoomResponseDto(
-        Long id
-) {
+        Long id,
+        Long participateId) {
 }

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/CreateStudyRoomServiceTest.java
@@ -1,8 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.applications;
 
-import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
 import com.pomodoro.pomodoromate.studyRoom.dtos.CreateStudyRoomRequest;
-import com.pomodoro.pomodoromate.studyRoom.exceptions.StudyAlreadyCompletedException;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomInfo;
 import com.pomodoro.pomodoromate.studyRoom.repositories.StudyRoomRepository;
@@ -12,19 +10,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-@ActiveProfiles("test")
 class CreateStudyRoomServiceTest {
     private StudyRoomRepository studyRoomRepository;
     private ValidateUserService validateUserService;
-    private ParticipateService participateService;
     private PasswordEncoder passwordEncoder;
     private CreateStudyRoomService createStudyRoomService;
 
@@ -32,10 +26,9 @@ class CreateStudyRoomServiceTest {
     void setUp() {
         studyRoomRepository = mock(StudyRoomRepository.class);
         validateUserService = mock(ValidateUserService.class);
-        participateService = mock(ParticipateService.class);
         passwordEncoder = mock(Argon2PasswordEncoder.class);
         createStudyRoomService = new CreateStudyRoomService(
-                studyRoomRepository, validateUserService, participateService, passwordEncoder);
+                studyRoomRepository, validateUserService, passwordEncoder);
     }
 
     @Test

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/controllers/StudyRoomControllerTest.java
@@ -4,6 +4,7 @@ import com.pomodoro.pomodoromate.auth.config.JwtConfig;
 import com.pomodoro.pomodoromate.auth.utils.JwtUtil;
 import com.pomodoro.pomodoromate.common.dtos.PageDto;
 import com.pomodoro.pomodoromate.config.SecurityConfig;
+import com.pomodoro.pomodoromate.participant.applications.ParticipateService;
 import com.pomodoro.pomodoromate.studyRoom.applications.CreateStudyRoomService;
 import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomService;
 import com.pomodoro.pomodoromate.studyRoom.applications.GetStudyRoomsService;
@@ -47,6 +48,9 @@ class StudyRoomControllerTest {
 
     @MockBean
     private StudyProgressService studyProgressService;
+
+    @MockBean
+    private ParticipateService participateService;
 
     @SpyBean
     private JwtUtil jwtUtil;


### PR DESCRIPTION
- 스터디룸 생성 시, 생성자는 자동으로 방에 추가되는데 참가자 id를 넘겨주지 않아서 본인 id를 알 수 없었음
- 응답값에 참가자 id도 포함하여 해결