### PR TITLE
Fix: 다음 단계 진행 시, 타이머 시간이 갱신이 안되는 이슈 해결

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/common/models/BaseEntity.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/models/BaseEntity.java
@@ -1,19 +1,22 @@
 package com.pomodoro.pomodoromate.common.models;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
     @Column(updatable = false)
-    @CreationTimestamp
+    @CreatedDate
     private LocalDateTime createAt;
 
-    @UpdateTimestamp
+    @LastModifiedDate
     private LocalDateTime updateAt;
 
     public LocalDateTime createAt() {

--- a/src/main/java/com/pomodoro/pomodoromate/config/JpaAuditingConfig.java
+++ b/src/main/java/com/pomodoro/pomodoromate/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.pomodoro.pomodoromate.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
@@ -11,7 +11,6 @@ import com.pomodoro.pomodoromate.user.models.User;
 import com.pomodoro.pomodoromate.user.models.UserId;
 import com.pomodoro.pomodoromate.user.repositories.UserRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 

--- a/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/studyRoom/applications/StudyProgressServiceTest.java
@@ -1,5 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.applications;
 
+import com.pomodoro.pomodoromate.config.JpaAuditingConfig;
 import com.pomodoro.pomodoromate.participant.exceptions.ParticipantNotInRoomException;
 import com.pomodoro.pomodoromate.participant.models.Participant;
 import com.pomodoro.pomodoromate.participant.repositories.ParticipantRepository;


### PR DESCRIPTION
- 다음 스터디 단계 진행 시, 타이머 시간이 갱신이 안되는 이슈 발생
- 원인: 스터디가 갱신되면서 엔티티가 업데이트 되는 시간인 updateAt을 활용해서 타이머 시작시간을 계산하고 있었음
  - 그런데 다음 단계 진행 api 호출 시, 시간이 업데이트 되기 전에 시간 정보를 보내서 이슈가 발생함
- 해결: 다음단계 진행 시, updateAt을 자동이 아닌 수동으로 변경하도록 코드 수정